### PR TITLE
[Linux] [Fix] Use exact path casing.

### DIFF
--- a/iTools_nodes.py
+++ b/iTools_nodes.py
@@ -120,7 +120,7 @@ class IToolsPromptLoader:
         prompt = ""
         count = 0
         if file_path == "prompts.txt":
-            file = os.path.join(p, "ComfyUi-iTools", "examples", "prompts.txt")
+            file = os.path.join(p, "ComfyUI-iTools", "examples", "prompts.txt")
         else:
             file = file_path.replace('"', '')
         if os.path.exists(file):
@@ -156,7 +156,7 @@ class IToolsPromptSaver:
 
     def save_to_file(self, file_path, prompt):
         if file_path == "prompts.txt":
-            file = os.path.join(p, "ComfyUi-iTools", "examples", "prompts.txt")
+            file = os.path.join(p, "ComfyUI-iTools", "examples", "prompts.txt")
         else:
             file = file_path.replace('"', '')
         if os.path.exists(file) and prompt is not None and prompt != "":

--- a/metadata/prompter.py
+++ b/metadata/prompter.py
@@ -4,13 +4,13 @@ from .shared import *
 
 
 file_name = "basic.yaml"
-file_path = os.path.join(p, "ComfyUi-iTools", "styles", file_name)
+file_path = os.path.join(p, "ComfyUI-iTools", "styles", file_name)
 yaml_data = load_yaml_data(file_path)
 templates = read_styles(yaml_data)
 
 
 def read_replace_and_combine(template_name, positive_prompt, negative_prompt, file_name):
-    file_path = os.path.join(p, "ComfyUi-iTools", "styles", file_name)
+    file_path = os.path.join(p, "ComfyUI-iTools", "styles", file_name)
 
     _yaml_data = load_yaml_data(file_path)
 
@@ -63,7 +63,7 @@ async def respond_to_js_message(request):
     file_name = post.get('message')
     # print("Post received", file_name)
 
-    file_path = os.path.join(p, "ComfyUi-iTools", "styles", file_name)
+    file_path = os.path.join(p, "ComfyUI-iTools", "styles", file_name)
     yaml_data = load_yaml_data(file_path)
     templates = read_styles(yaml_data)
 

--- a/metadata/prompter_multi.py
+++ b/metadata/prompter_multi.py
@@ -3,22 +3,22 @@ from aiohttp import web
 from .shared import *
 
 file_name_basic = "basic.yaml"
-file_path_basic = os.path.join(p, "ComfyUi-iTools", "styles", file_name_basic)
+file_path_basic = os.path.join(p, "ComfyUI-iTools", "styles", file_name_basic)
 yaml_data_basic = load_yaml_data(file_path_basic)
 templates_basic = read_styles(yaml_data_basic)
 
 file_name_extra1 = "camera.yaml"
-file_path_extra1 = os.path.join(p, "ComfyUi-iTools", "styles", file_name_extra1)
+file_path_extra1 = os.path.join(p, "ComfyUI-iTools", "styles", file_name_extra1)
 yaml_data_extra1 = load_yaml_data(file_path_extra1)
 templates_extra1 = read_styles(yaml_data_extra1)
 
 file_name_extra2 = "artist.yaml"
-file_path_extra2 = os.path.join(p, "ComfyUi-iTools", "styles", file_name_extra2)
+file_path_extra2 = os.path.join(p, "ComfyUI-iTools", "styles", file_name_extra2)
 yaml_data_extra2 = load_yaml_data(file_path_extra2)
 templates_extra2 = read_styles(yaml_data_extra2)
 
 file_name_extra3 = "mood.yaml"
-file_path_extra3 = os.path.join(p, "ComfyUi-iTools", "styles", file_name_extra3)
+file_path_extra3 = os.path.join(p, "ComfyUI-iTools", "styles", file_name_extra3)
 yaml_data_extra3 = load_yaml_data(file_path_extra3)
 templates_extra3 = read_styles(yaml_data_extra3)
 
@@ -26,7 +26,7 @@ templates_extra3 = read_styles(yaml_data_extra3)
 def get_template_value_from_yaml_file(file_name, template_name):
     positive_prompt = ""
     negative_prompt = ""
-    file_path = os.path.join(p, "ComfyUi-iTools", "styles", file_name)
+    file_path = os.path.join(p, "ComfyUI-iTools", "styles", file_name)
     _yaml_data = load_yaml_data(file_path)
 
     try:
@@ -95,7 +95,7 @@ def combine_multi(text_positive, text_negative,
 async def respond_to_request_templates_for_file(request):
     post = await request.post()
     file_name = post.get("file_name")
-    file_path = os.path.join(p, "ComfyUi-iTools", "styles", file_name)
+    file_path = os.path.join(p, "ComfyUI-iTools", "styles", file_name)
     yaml_data = load_yaml_data(file_path)
     templates = read_styles(yaml_data)
     data = {"templates": templates}

--- a/metadata/shared.py
+++ b/metadata/shared.py
@@ -84,5 +84,5 @@ def read_styles(_yaml_data):
 
 
 p = folder_paths.folder_names_and_paths["custom_nodes"][0][0]
-folder_path = os.path.join(p, "ComfyUi-iTools", "styles")
+folder_path = os.path.join(p, "ComfyUI-iTools", "styles")
 styles = get_yaml_names(folder_path)


### PR DESCRIPTION
Fixes #3

Due to missmatch of extension directory name, it wouldn't work on linux, import will fail, also .yaml files with styles wouldn't be found.