### PR TITLE
fix: restore control_after_generate popover on Line Loader in Node 2.0

### DIFF
--- a/iTools_nodes.py
+++ b/iTools_nodes.py
@@ -505,7 +505,7 @@ class IToolsLineLoader:
                     "INT",
                     {
                         "default": 0,
-                        "control_after_generate": "increment",
+                        "control_after_generate": True,
                         "min": 0,
                         "max": 0xFFF,
                     },

--- a/web/line_loader_node.js
+++ b/web/line_loader_node.js
@@ -1,0 +1,19 @@
+import { app } from "../../../scripts/app.js";
+
+const _id = "iToolsLineLoader";
+
+app.registerExtension({
+  name: "makadi." + _id,
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData.name !== _id) {
+      return;
+    }
+    const onNodeCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      const me = onNodeCreated?.apply(this);
+      const cag = this.widgets?.find((w) => w.name === "control_after_generate");
+      if (cag) cag.value = "increment";
+      return me;
+    };
+  },
+});


### PR DESCRIPTION
Hi I am Terry, from ComfyUI Frontend team.
Vue Node 2.0 looks up the linked control widget by the literal name 'control_after_generate'. Passing a string value renames the widget, so the popover never renders. Use True and set the initial mode in JS.
<img width="1235" height="744" alt="image" src="https://github.com/user-attachments/assets/2a2127a4-5dc6-447d-af3a-60a7cf0121e6" />
